### PR TITLE
Update DocumentationController authorization

### DIFF
--- a/src/Http/Controllers/DocumentationController.php
+++ b/src/Http/Controllers/DocumentationController.php
@@ -48,7 +48,7 @@ class DocumentationController extends Controller
         $documentation = $this->documentationRepository->get($version, $page);
 
         if (Gate::has('viewLarecipe')) {
-            $this->authorize('viewLarecipe', $documentation);
+            $this->authorize('viewLarecipe');
         }
 
         if ($this->documentationRepository->isNotPublishedVersion($version)) {


### PR DESCRIPTION
Remove $documentation parameter from authorization method, because it does not work with https://github.com/JosephSilber/bouncer package (argument passed to function must be an instance of Eloquent\Model, DocumentationRepository given)